### PR TITLE
将线路名称的类型改为string

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ class Response(object):
         return {'error': self.error, 'msg': self.msg, 'data': self.data}
 
 
-@app.route('/api/v1/stations/<string:stop_type>/<int:number>/')
+@app.route('/api/v1/stations/<string:stop_type>/<string:number>/')
 def get_stations(stop_type, number):
     if stop_type not in ['up', 'down']:
         return jsonify(Response(error=1, msg='stop type error').dumps())
@@ -25,7 +25,7 @@ def get_stations(stop_type, number):
     return jsonify(Response(error=0, msg='', data=stations).dumps())
 
 
-@app.route('/api/v1/stops/<string:stop_type>/<int:number>/')
+@app.route('/api/v1/stops/<string:stop_type>/<string:number>/')
 def get_stops(stop_type, number):
     if stop_type not in ['up', 'down']:
         return jsonify(Response(error=1, msg='stop type error').dumps())


### PR DESCRIPTION
有些线路名称里包含汉字，number类型为int型就查询不到结果了，所以把number改为string型